### PR TITLE
fix: make handleCellClick asynchronous to await board generation on f…

### DIFF
--- a/static/minesweeper.js
+++ b/static/minesweeper.js
@@ -217,7 +217,7 @@ function generateBoard(excludeRow, excludeCol) {
  * @param {MouseEvent} event - The click event on the cell.
  * @param {boolean} [fromRight=false] - Indicates if the click originated from a right-click handler to prevent recursive toggling.
  */
-function handleCellClick(event,fromRight=false) {
+async function handleCellClick(event, fromRight = false) {
     if (gameOver) return;
 
     const cell = event.currentTarget;
@@ -227,7 +227,7 @@ function handleCellClick(event,fromRight=false) {
     if (flagged[r][c]) return;
 
     if (firstClick) {
-        generateBoard(r, c);
+        await generateBoard(r, c);
         firstClick = false;
     }
 


### PR DESCRIPTION
…irst click

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of the first click in Minesweeper by ensuring the board is fully generated before continuing with game actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->