### PR TITLE
Merge pull request #22 from ArchooD2/main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 *.db
 .env
+test_*.py

--- a/static/css/foster.css
+++ b/static/css/foster.css
@@ -1,0 +1,73 @@
+body {
+  background: #0a0a0a;
+  color: #f0f0f0;
+}
+
+.container {
+  background: #1a1a1a;
+  box-shadow: 0 0 10px rgba(255, 0, 0, 0.15);
+  color: #f0f0f0;
+}
+
+button {
+  background-color: #700000;
+  color: #ffffff;
+}
+
+button:hover {
+  background-color: #330000;
+  color: #ffcccc;
+}
+
+#game-container td {
+  border: 1px solid #444;
+  background-color: #2a2a2a;
+}
+
+#game-container td:hover {
+  background-color: #3a3a3a;
+}
+
+#game-container td.revealed {
+  background-color: #0f0f0f;
+}
+
+#game-container td.flagged {
+  color: #ff4444;
+}
+
+#game-container td.mine {
+  background-color: #b00020;
+}
+
+@keyframes pulse {
+  0% { background-color: #b00020; }
+  100% { background-color: #ff1744; }
+}
+
+.chording-hover {
+  background-color: #330000 !important;
+}
+
+.number-1 { color: #ffffff; }
+.number-2 { color: #bbbbbb; }
+.number-3 { color: #ff6666; }
+.number-4 { color: #ff9999; }
+.number-5 { color: #ffcccc; }
+.number-6 { color: #ff0000; }
+.number-7 { color: #888888; }
+.number-8 { color: #aaaaaa; }
+
+.changelog-entry {
+  background: #191919;
+  box-shadow: 0 0 5px rgba(255,0,0,0.1);
+  color: #ddd;
+}
+
+.changelog-meta {
+  color: #aaa;
+}
+
+.changelog-message {
+  color: #eee;
+}

--- a/static/css/godot.css
+++ b/static/css/godot.css
@@ -1,0 +1,72 @@
+body {
+  background: #1b1e23;
+  color: #d7dfe7;
+}
+
+.container {
+  background: #242830;
+  box-shadow: 0 0 10px rgba(0, 170, 255, 0.1);
+  color: #d7dfe7;
+}
+
+button {
+  background-color: #2e3a4a;
+  color: #d7dfe7;
+}
+
+button:hover {
+  background-color: #3a4a5a;
+}
+
+#game-container td {
+  border: 1px solid #3f4d5c;
+  background-color: #2b313b;
+}
+
+#game-container td:hover {
+  background-color: #3c4452;
+}
+
+#game-container td.revealed {
+  background-color: #20242b;
+}
+
+#game-container td.flagged {
+  color: #70c7ff;
+}
+
+#game-container td.mine {
+  background-color: #007acc;
+}
+
+@keyframes pulse {
+  0% { background-color: #005f9e; }
+  100% { background-color: #70c7ff; }
+}
+
+.chording-hover {
+  background-color: #35404f !important;
+}
+
+.number-1 { color: #82aaff; }
+.number-2 { color: #c3e88d; }
+.number-3 { color: #f07178; }
+.number-4 { color: #c792ea; }
+.number-5 { color: #ffcb6b; }
+.number-6 { color: #89ddff; }
+.number-7 { color: #eeeeee; }
+.number-8 { color: #999999; }
+
+.changelog-entry {
+  background: #23272f;
+  box-shadow: 0 0 5px rgba(0,170,255,0.15);
+  color: #c0d3e6;
+}
+
+.changelog-meta {
+  color: #8fa3bb;
+}
+
+.changelog-message {
+  color: #d7e3ef;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,6 +25,8 @@
           <option value="dark">🌙 Dark</option>
           <option value="void">🕳 Void</option>
           <option value="ryan">🔥 Ryan</option>
+          <option value="foster">🐦 Foster</option>
+          <option value="godot">👾 Godot</option>
           <option value="mocha">☕ Mocha</option>
           <option value="slate">🪨 Slate</option>
           <option value="nebula">🌌 Nebula</option>


### PR DESCRIPTION
add Foster and Godot Themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced two new dark themes, "Foster" and "Godot", available in the theme selector.
  - Added new dark-themed visual styles for both "Foster" and "Godot" themes, including updated backgrounds, button styles, and color-coded game elements.
- **Chores**
  - Updated file ignore rules to exclude all Python test files starting with `test_`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->