### PR TITLE
chore: add .gitattributes to mark static/css as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+static/css/** linguist-vendored=true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated repository settings to mark files in the `static/css/` directory as vendored, affecting how they appear in GitHub statistics and search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->